### PR TITLE
centos-6.6: Force to set SELinux to a permissive mode

### DIFF
--- a/packer/http/centos-6.6/ks.cfg
+++ b/packer/http/centos-6.6/ks.cfg
@@ -62,6 +62,8 @@ nfs-utils
 -zd1211-firmware
 
 %post
+# Force to set SELinux to a permissive mode
+sed -i -e 's/\(^SELINUX=\).*$/\1permissive/' /etc/selinux/config
 # update root certs
 wget -O/etc/pki/tls/certs/ca-bundle.crt http://curl.haxx.se/ca/cacert.pem
 # sudo


### PR DESCRIPTION
In the CentOS 6.6 distribution SELinux is set to "enforcing" instead of "permissive" regardless of the fact that `ks.cfg` contains the line `selinux --permissive`.
This line is ignored by anaconda and the resulted box has the following SELinux configuration:

```bash
$  sestatus
SELinux status:                 enabled
SELinuxfs mount:                /selinux
Current mode:                   enforcing
Mode from config file:          enforcing
Policy version:                 24
Policy from config file:        targeted

$ cat /etc/selinux/config

# This file controls the state of SELinux on the system.
# SELINUX= can take one of these three values:
#     enforcing - SELinux security policy is enforced.
#     permissive - SELinux prints warnings instead of enforcing.
#     disabled - No SELinux policy is loaded.
SELINUX=enforcing
# SELINUXTYPE= can take one of these two values:
#     targeted - Targeted processes are protected,
#     mls - Multi Level Security protection.
SELINUXTYPE=targeted
```

I've noticed that it is reproduced only on **centos-6.6**. If we build "centos-7.0" box, or even try to reset to 99cacf4 and build "centos-6.5" box, then there will be SELinux in the permissive mode.

Seems like CentOS 6.6 has a 'broken' anaconda installer?  The similar issue was detected in older RedHat version, but it was not fixed: https://bugzilla.redhat.com/show_bug.cgi?id=435300

So, I've applied the workaround from the link above.